### PR TITLE
fix: replace removed dart-sass-embedded snap with dart-sass

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -38,8 +38,8 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb          
-      - name: Install Dart Sass Embedded
-        run: sudo snap install dart-sass-embedded
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The dart-sass-embedded snap package was deprecated and removed when Dart Sass merged the embedded protocol into its main binary. This caused the build job to fail on every push, preventing the site from ever updating.

https://claude.ai/code/session_01L9DRksvRzKe6Ke4uueSGMT